### PR TITLE
admin/item,genreのサクセスメッセージ以外の実装

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -6,8 +6,13 @@ class Admin::GenresController < ApplicationController
 
   def create
     @genre = Genre.new(genre_params)
-    @genre.save
-    redirect_to admin_genres_path #編集一覧に戻る
+    if @genre.save
+      redirect_to admin_genres_path #編集一覧に戻る
+      flash[:notice] = '新しいジャンルを登録しました。'
+    else
+      @genres = Genre.all
+      render :index
+    end
   end
 
   def edit
@@ -16,8 +21,12 @@ class Admin::GenresController < ApplicationController
 
   def update
     @genre = Genre.find(params[:id])
-    @genre.update(genre_params)
-     redirect_to admin_genre_path
+    if @genre.update(genre_params)
+      redirect_to admin_genres_path
+      flash[:notice] = "ジャンルが変更されました。"
+    else
+      render :edit
+    end
   end
   
   private

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -32,9 +32,10 @@ class Admin::ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to admin_item_path(@item.id)
       flash[:notice] = '商品情報を編集しました'
-    # else
-    # render "edit"
+    else
+      render :"show"
     end
+    
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,4 +12,7 @@ class Item < ApplicationRecord
     (item_image.attached?) ? item_image : 'no_image.jpg'
   end
   
+   def add_tax_price
+        (self.price * 1.10).round
+   end
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,20 +1,20 @@
 <div class="row">
   <div class="col-md">
     <h2>ジャンル編集</h2>
-     <%= form_with model: @genre, url: admin_genre_path(@genre.id), method: :patch do |f| %>
-      <div class="table">
-        <tr>
-         <td>
-          <label for="name">ジャンル名</label>
-         </td>
-         <td>
-          <%= f.text_field :name, class: "form-control" %>
-         </td>
-         <td>
-          <%= link_to "変更を保存", admin_genres_path(@item), class: 'btn btn-secondary' %>
-         </td>
-        </tr>
-      </div>
-    <% end %>
+     <tbody>
+      <%= form_with model: @genre, url: admin_genre_path do |f| %>
+        <div class="table">
+          <tr>
+            <td><label for="name">ジャンル名</label></td>
+            <td>
+              <%= f.text_field :name %>
+            </td>
+            <td>
+              <%= f.submit "変更を保存", class: "btn btn-success" %>
+            </td>
+          </tr>
+        </div>
+        <% end %>
+     </tbody>
   </div>
-</div> 
+</div>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,42 +1,41 @@
-<div class="row">
- <div class="col-md-8">
-  <table class="table">
-   <thead>
-    <h2>ジャンル一覧・追加</h2><br>
-  </thead>
-  <tbody>
-     <%= form_with model: @genre, url: admin_genres_path, method: :post do |f| %>
-       <label for="name">ジャンル名</label><br>
-         <%= f.text_field :name, class:"form-control" %>
-       <%= f.submit '新規登録', class:"btn btn-success" %>
-  </tbody>
-  </table>
- </div>
-</div>
-<% end %>
-<br>
-
-<!--二段に切り替える-->
-
-<div class="row ">
-<div class="col-md-6">
-
-  <table class = "table">
-    <thead>
-      <tr class="active">
-        <th>ジャンル</th>
-        <th></th>
-        <th colspan="1"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @genres.each do |genre| %>
-      <tr>
-        <td><%= genre.name %></td>
-        <td><%= link_to "編集する", edit_admin_genre_path(genre.id) ,class: "btn btn-success" %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
+<div clas<div class="row">
+  <div class="col-md">
+    <table class="table">
+      <thead>
+        <h2>ジャンル一覧・追加</h2><br> </thead>
+      <tbody>
+        <%= form_with model: @genre, url: admin_genres_path, method: :post do |f| %> <label>ジャンル名</label>
+          <tr>
+            <%= f.text_field :name, placeholder: "ジャンル名" %>
+              <%= f.submit '新規登録', class:"btn btn-success" %>
+          </tr>
+      </tbody>
+    </table>
   </div>
 </div>
+<% end %> <br>
+  <!--二段に切り替える-->
+  <div class="row ">
+    <div class="col-md-5">
+      <table class="table">
+        <thead>
+          <tr class="active">
+            <th>ジャンル</th>
+            <th colspan="3"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @genres.each do |genre| %>
+            <tr>
+              <td>
+                <%= genre.name %>
+              </td>
+              <td>
+                <%= link_to "編集する", edit_admin_genre_path(genre) ,class: "btn btn-success" %>
+              </td>
+            </tr>
+            <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,36 +1,39 @@
 <div class="row">
   <div class="col-md-6 offset-md-1">
     <h2 class="text-left">商品編集</h2>
-    <%= form_with model:@item, url: admin_item_path, method: :patch do |f| %>
-    
-      <form>
-        <%= f.label :商品画像 %>
-          <%= f.file_field :image, accept: "image/*" %>
-            <div class="form-group">
-              <%= f.label :商品名 %>
-                <%= f.text_field :name %>
-            </div>
-            <div class="form-group">
-              <%= f.label :商品説明 %>
-                <%= f.text_area :introduction %>
-            </div>
-            <div class="form-group">  <!--複数のリストから選択するドロップダウンリスト-->
-              <%= f.label :ジャンル %>
-                <%= f.collection_select :genre_id, Genre.all, :id, :name,{prompt: "選択してください"} %>
-                  <!-- ジャンル未作成 -->
-            </div>
-            <div class="form-group">
-              <%= f.label :税抜価格 %>
-                <%= f.text_field :price %>円 </div>
-            <!--  %= f.label :販売ステータス %>-->
-            <!--  %= f.radio_button :sales_status, Item.sales_statuses.key(0) %>-->
-            <!--  %= f.label :sales_status, Item.sales_statuses_i18n[:sale] %>-->
-            <!--  %= f.radio_button :sales_status, Item.sales_statuses.key(1) %>-->
-            <!--  %= f.label :sales_status, Item.sales_statuses_i18n[:stop_selling] %>-->
-            <!--</div>-->
-            <%= link_to "変更を保存", admin_item_path(@item), class: 'btn btn-secondary' %>
-           
-      </form>
+     <p id="notice"></p>
+       <%= form_with model:@item, url: admin_item_path, method: :patch do |f| %>
+        <form>
+          <%= f.label :商品画像 %>
+            <%= f.file_field :image, accept: "image/*" %>
+              <div class="form-group">
+                <p id="notice"></p>
+                 <%= f.label :商品名 %>
+                  <%= f.text_field :name %>
+              </div>
+              <div class="form-group">
+                <p id="notice"></p>
+                 <%= f.label :商品説明 %>
+                  <%= f.text_area :introduction %>
+              </div>
+              <div class="form-group">
+                <!--複数のリストから選択するドロップダウンリスト-->
+                 <%= f.label :ジャンル %>
+                  <%= f.collection_select :genre_id, Genre.all, :id, :name,{prompt: "選択してください"} %>
+              <div class="form-group">
+                <p id="notice"></p>
+                 <%= f.label :税抜価格 %>
+                  <%= f.text_field :price %>円
+              </div>
+                <td><%= f.label :is_active, "販売ステータス" %></td>
+                    <%= f.radio_button :is_active, :true ,{:checked => true} %>
+                    <%= f.label :is_active, "販売中" %>
+                    <%= f.radio_button :is_active, :false %>
+                    <%= f.label :is_active, "販売停止中" %>
+                 <p id="notice"></p>
+            <%= f.submit "変更を保存", class: "btn btn-success" %><%#= or  link_to "変更を保存", admin_item_path(@item.id), class: 'btn btn-success' %>
+                                  <%# 削除ボタンもつける%>
+        </form>
       <% end %>
   </div>
 </div>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -2,39 +2,40 @@
   <h1 class="text-right">
     <%= link_to "+", new_admin_item_path %>
   </h1>
-  <h2>商品一覧</h2>
-  <table class="table thead-class">
-    <tbody>
-      <tr class="table-secondary">
-        <th>商品ID</th>
-        <th>商品名</th>
-        <th>税抜価格</th>
-        <th>ジャンル</th>
-        <th>ステータス</th>
-      </tr>
-      <% @items.each do |item| %>
-        <tr>
-          <td>
-            <%= item.id %>
-          </td>
-          <td>
-            <%= link_to item.name, admin_item_path(item) %>
-          </td>
-          <td>
-            <%= item.price %>
-          </td>
-          <td>
-            <%= item.genre.name %>
-          </td>
-          <td>
-            <% if item.is_active %>
-              <%# is_activeの情報を取得して在庫があるかチェック %> <b class="text-success">販売中</b>
-                <%# trueの時の表示 %>
-                  <% else %> <b class="text-secondary">販売停止中</b>
-                    <%# falseの時の表示 %>
-                      <% end %>
-          </td>
-        </tr>
-        <% end %>
-  </table>
+    <h2>商品一覧</h2>
+      <p id="notice"></p>
+      <table class="table thead-class">
+          <tr class="table-secondary">
+              <th>商品ID</th>
+                  <th>商品名</th>
+                     <th>税抜価格</th>
+                  <th>ジャンル</th>
+              <th>ステータス</th>
+          </tr>
+          <% @items.each do |item| %>
+            <tr>
+              <td>
+                <%= item.id %>
+              </td>
+              <td>
+                <%= link_to item.name, admin_item_path(item) %>
+              </td>
+              <td>
+                <%= item.price %>
+                  <%# [.to_s(:delimited)]３桁ごとにカンマ表記] 出来ていない %>
+              </td>
+              <td>
+                <%= item.genre.name %>
+              </td>
+              <td>
+                <% if item.is_active %><%# is_activeの情報を取得して在庫があるかチェック %>
+                  <b class="text-success">
+                    販売中</b><%# trueの時の表示 %>
+                <% else %> <b class="text-secondary">
+                    販売停止中</b><%# falseの時の表示 %>
+                <% end %>
+              </td>
+            </tr>
+            <% end %>
+      </table>
 </div>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -2,50 +2,46 @@
   <div class="row">
     <div class="col-md-6">
       <h2 class="text-left">商品新規登録</h2>
+      <p id="notice"></p>
         <%= form_with model:@item, url: admin_items_path, method: :post do |f| %>
-         <form>
-           
+          <form>
             <div class="form-group">
-              <%= f.label :商品画像 %>
-              <%= f.file_field :image, placeholder: "選択されていません", accept: "image/*" %>
+              <p id="notice"></p>
+               <%= f.label :商品画像 %>
+                <%= f.file_field :image, placeholder: "選択されていません", accept: "image/*" %>
             </div>
-             
             <div class="form-group">
-              <%= f.label :商品名 %>
-              <%= f.text_field :name, placeholder: "商品名" %>
+              <p id="notice"></p>
+               <%= f.label :商品名 %>
+                <%= f.text_field :name, placeholder: "商品名" %>
             </div>
-            
             <div class="form-group">
-              <%= f.label :商品説明 %>
-              <%= f.text_area :introduction, placeholder: "ここに説明文を記述します" %>
-            </div>
-            
-            <!--<div class="form-group">-->
-            <!--  %= f.label :ジャンル %>-->
-            <!--  %= f.collection_select :genre_id, Genre.all, :id, :name,{prompt: "選択してください"} %>-->
-            <!--</div>-->
-            
-            <div class="form-group">
-              <%= f.label :税抜価格 %>
-              <%= f.text_field :price, placeholder: 1000 %>円
+              <p id="notice"></p>
+               <%= f.label :商品説明 %>
+                <%= f.text_area :introduction, placeholder: "ここに説明文を記述します" %>
             </div>
             <div>
+              <p id="notice"></p>
               <%= f.label:ジャンル %>
-              <%= f.select :genre_id, Genre.all.map { |genre| [genre.name, genre.id] } %>
-              <%= f.radio_button :is_active, :true ,{:checked => true} %>
-              <%= f.label :is_active, "販売中" %>
-              <%= f.radio_button :is_active, :false %>
-              <%= f.label :is_active, "販売停止中" %>
+              <%= f.collection_select :genre_id, Genre.all, :id, :name,{prompt: "選択してください"} %>
             </div>
             <div class="form-group">
-            <%= f.submit "新規登録", class: 'btn btn-secondary'  %>  <!-- or  %= link_to "新規登録", admin_item_path, class: 'btn btn-secondary' %>-->
-            </div>
-         </form>
-        <% end %>
+              <p id="notice"></p>
+               <%= f.label :税抜価格 %>
+                <%= f.text_field :price, placeholder: 1000 %>円 </div>
+            <td>
+              <%= f.label :is_active, "販売ステータス" %>
+            </td>
+              <%= f.radio_button :is_active, :true ,{:checked => true} %>
+                  <%= f.label :is_active, "販売中" %>
+                  <%= f.radio_button :is_active, :false %>
+                <%= f.label :is_active, "販売停止中" %>
+              <div class="form-group">
+                <p id="notice"></p>
+                <%= f.submit "新規登録", class: 'btn btn-success'  %> <!-- or  %= link_to "新規登録", admin_item_path, class: 'btn btn-secondary' %>-->
+              </div>
+          </form>
+          <% end %>
     </div>
   </div>
 </div>
-
-  
-  
-    

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,34 +1,58 @@
 <div class="conteiner">
   <div class="row">
-    <div class="col-md-3">
+    <div class="col-md-9">
       <h2 class="text-left">商品詳細</h2>
-        <!--%= image_tag @item.image, size: "200x200" %>-->　<!--未完成-->
-          <table class="table">
-            <tr>
-              <th>商品名</th>
-              <td><%= @item.name %></td>
-            </tr>
-              
-            <tr>
-              <th>商品説明</th>
-              <td><%= @item.introduction %></td>
-            </tr>
-            
-            <tr>
-              <th>ジャンル</th>
-              <td><%= @item.genre.name %></td>
-            </tr>
-            
-            <tr>
-              <th> 税込価格<br> （税抜価格） </th>
-              <!--<td>%= @item.with_tax_price.to_s(:delimited) %>円<br>-->
-              <!--  （%= number_with_delimiter(@item.price) %>円）</td>-->
-            </tr>
-            <tr>
-              <th>販売ステータス</th><!--<td>%= @item.is_active %></td>-->
-            </tr>
-          </table>
-            <%= link_to "編集する", edit_admin_item_path(@item), class: 'btn btn-secondary' %> 
+      <tr>
+        <% if @item.image.attached? %>
+          <%= image_tag @item.image, size: "200x200" %>
+        <% else %>
+          <%= image_tag 'no_image', size: "200x200" %>
+        <% end %>
+      </tr>
+      <table class="table">
+        <tbody>
+          <tr>
+            <th>商品名</th>
+            <td>
+              <%= @item.name %>
+            </td>
+          </tr>
+          <tr>
+            <th>商品説明</th>
+            <td>
+              <%= @item.introduction %>
+            </td>
+          </tr>
+          <tr>
+            <th>ジャンル</th>
+            <td>
+              <%= @item.genre.name %>
+            </td>
+          </tr>
+          <tr>
+            <th> 税込価格<br> （税抜価格） </th>
+            <td>
+              <%= @item.add_tax_price.to_s(:delimited) %>(
+                <%= @item.price.to_s(:delimited) %>)円</td>
+          </tr>
+          <tr>
+            <td>販売ステータス</td>
+            <td>
+              <% if @item.is_active %><%# is_activeの情報を取得して在庫があるかチェック %>
+              販売中<%# trueの表示がでる %>
+              <% else %>
+              販売停止中<%# falseの表示がでる %>
+              <% end %>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <%= link_to "編集する", edit_admin_item_path(@item.id), class: 'btn btn-success' %>
+            </td>
+            <%# 商品一覧画面に戻るボタンもつける%>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>


### PR DESCRIPTION

admin/item
・itemの編集と更新が動かなかったため修正しました。
・税抜価格（税込価格）表示のコード追加
・ドロップダウンリストを追加
genre
・ジャンルの編集と更新の実装修正

レイアウト修正、サクセスメッセージはまだです。